### PR TITLE
6 import時に補完がきくように修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,5 +32,8 @@
     "ts-jest": "^29.0.5",
     "ts-node": "^10.9.1",
     "typescript": "^4.9.5"
-  }
+  },
+  "files": [
+    "dist"
+  ]
 }


### PR DESCRIPTION
vscodeにインストールしている拡張（christian-kohler.npm-intellisense）で、devDependenciesにインストールしているパッケージは補完されないようだったので解決

vscodeの`settings.json`に下記を追加すると、devDependenciesのパッケージも読み込みされ、補完がされる
`{ npm-intellisense.scanDevDependencies": true }`


close #6